### PR TITLE
feat: Trip packing lists (personal + group)

### DIFF
--- a/backend/migrations/010_trip_packing.sql
+++ b/backend/migrations/010_trip_packing.sql
@@ -1,0 +1,81 @@
+-- Personal (per-member) and shared group packing checklists per trip.
+CREATE TABLE IF NOT EXISTS trip_packing_items (
+  id TEXT NOT NULL,
+  trip_id TEXT NOT NULL REFERENCES trips(id) ON DELETE CASCADE,
+  user_id TEXT NULL,
+  label TEXT NOT NULL DEFAULT '',
+  is_checked BOOLEAN NOT NULL DEFAULT false,
+  sort_order INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (id),
+  UNIQUE (trip_id, id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_trip_packing_items_trip_user ON trip_packing_items (trip_id, user_id);
+
+ALTER TABLE trip_packing_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Members can read trip_packing_items"
+  ON trip_packing_items FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM trip_members
+      WHERE trip_members.trip_id = trip_packing_items.trip_id AND trip_members.user_id = auth.uid()::text
+    )
+    AND (
+      trip_packing_items.user_id IS NULL
+      OR trip_packing_items.user_id = auth.uid()::text
+    )
+  );
+
+CREATE POLICY "Members can insert trip_packing_items"
+  ON trip_packing_items FOR INSERT TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM trip_members
+      WHERE trip_members.trip_id = trip_packing_items.trip_id AND trip_members.user_id = auth.uid()::text
+    )
+    AND (
+      trip_packing_items.user_id IS NULL
+      OR trip_packing_items.user_id = auth.uid()::text
+    )
+  );
+
+CREATE POLICY "Members can update trip_packing_items"
+  ON trip_packing_items FOR UPDATE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM trip_members
+      WHERE trip_members.trip_id = trip_packing_items.trip_id AND trip_members.user_id = auth.uid()::text
+    )
+    AND (
+      trip_packing_items.user_id IS NULL
+      OR trip_packing_items.user_id = auth.uid()::text
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM trip_members
+      WHERE trip_members.trip_id = trip_packing_items.trip_id AND trip_members.user_id = auth.uid()::text
+    )
+    AND (
+      trip_packing_items.user_id IS NULL
+      OR trip_packing_items.user_id = auth.uid()::text
+    )
+  );
+
+CREATE POLICY "Members can delete trip_packing_items"
+  ON trip_packing_items FOR DELETE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM trip_members
+      WHERE trip_members.trip_id = trip_packing_items.trip_id AND trip_members.user_id = auth.uid()::text
+    )
+    AND (
+      trip_packing_items.user_id IS NULL
+      OR trip_packing_items.user_id = auth.uid()::text
+    )
+  );
+
+COMMENT ON TABLE trip_packing_items IS 'Packing rows: user_id NULL = shared group list; non-null = personal for that member.';

--- a/frontend/app/trips/[tripId]/packing/page.tsx
+++ b/frontend/app/trips/[tripId]/packing/page.tsx
@@ -1,0 +1,5 @@
+import { PackingPageContent } from "@/components/trips/pages/packing-page-content"
+
+export default function TripPackingPage() {
+  return <PackingPageContent />
+}

--- a/frontend/components/landing/roadmap-section.tsx
+++ b/frontend/components/landing/roadmap-section.tsx
@@ -13,6 +13,11 @@ const milestones: { label: string; detail: string; status: Status }[] = [
     status: "done",
   },
   {
+    label: "Packing lists",
+    detail: "Personal and group trip checklists, synced storage, mobile-friendly editing.",
+    status: "done",
+  },
+  {
     label: "Flights",
     detail: "SerpAPI Google Flights search, return flights, booking options.",
     status: "done",
@@ -78,7 +83,7 @@ export function RoadmapSection() {
           Where we&apos;re at.
         </h2>
         <p className="mt-4 text-muted-foreground max-w-xl">
-          Eight milestones from first line of code to production polish. Transparent progress, no vaporware.
+          Nine milestones from first line of code to production polish. Transparent progress, no vaporware.
         </p>
       </div>
 

--- a/frontend/components/trips/nav.ts
+++ b/frontend/components/trips/nav.ts
@@ -4,6 +4,7 @@ import {
   FileTextIcon,
   HotelIcon,
   LayoutDashboardIcon,
+  LuggageIcon,
   MapIcon,
   PlaneIcon,
   RouteIcon,
@@ -36,6 +37,7 @@ const baseTripNavItems: TripNavItem[] = [
   { key: "finance", label: "Finance", hrefSuffix: "/finance", icon: CircleDollarSignIcon },
   { key: "group", label: "Group", hrefSuffix: "/group", icon: UsersIcon },
   { key: "docs", label: "Documents", hrefSuffix: "/docs", icon: FileTextIcon },
+  { key: "packing", label: "Packing", hrefSuffix: "/packing", icon: LuggageIcon },
 ]
 
 /** Full nav list for international trips (default): no Buses & trains. */

--- a/frontend/components/trips/pages/packing-page-content.tsx
+++ b/frontend/components/trips/pages/packing-page-content.tsx
@@ -1,0 +1,297 @@
+"use client"
+
+import * as React from "react"
+import { flushSync } from "react-dom"
+import { PlusIcon, Trash2Icon } from "lucide-react"
+import { toast } from "sonner"
+
+import { useTripPage } from "@/components/trips/trip-shell"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import {
+  deletePackingItemFromSupabase,
+  listGroupPackingItemsFromSupabase,
+  listPersonalPackingItemsFromSupabase,
+  savePackingItemToSupabase,
+  updatePackingItemCheckedInSupabase,
+  type PackingItem,
+  type PackingScope,
+} from "@/lib/supabase-trip-packing"
+
+function nextSortOrder(items: PackingItem[]): number {
+  if (items.length === 0) return 0
+  return Math.max(...items.map((i) => i.sortOrder)) + 1
+}
+
+function newPackingId(tripId: string, scope: PackingScope): string {
+  return `${tripId}:pack:${scope}:${Date.now().toString(36)}`
+}
+
+export function PackingPageContent() {
+  const trip = useTripPage()
+  const [personal, setPersonal] = React.useState<PackingItem[]>([])
+  const [group, setGroup] = React.useState<PackingItem[]>([])
+  const [loading, setLoading] = React.useState(true)
+  const inputRefs = React.useRef<Map<string, HTMLInputElement>>(new Map())
+
+  const load = React.useCallback(async () => {
+    if (!trip?.id) return
+    setLoading(true)
+    try {
+      const [pRows, gRows] = await Promise.all([
+        listPersonalPackingItemsFromSupabase(trip.id),
+        trip.isGroupTrip ? listGroupPackingItemsFromSupabase(trip.id) : Promise.resolve([] as PackingItem[]),
+      ])
+      setPersonal(pRows)
+      setGroup(gRows)
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Could not load packing lists.")
+    } finally {
+      setLoading(false)
+    }
+  }, [trip?.id, trip?.isGroupTrip])
+
+  React.useEffect(() => {
+    void load()
+  }, [load])
+
+  const persistItem = async (
+    scope: PackingScope,
+    payload: PackingItem,
+    setList: React.Dispatch<React.SetStateAction<PackingItem[]>>
+  ) => {
+    if (!trip?.id) return
+    try {
+      await savePackingItemToSupabase(
+        trip.id,
+        {
+          id: payload.id,
+          label: payload.label,
+          isChecked: payload.isChecked,
+          sortOrder: payload.sortOrder,
+        },
+        scope
+      )
+      setList((prev) => {
+        const idx = prev.findIndex((x) => x.id === payload.id)
+        if (idx < 0) return [...prev, payload].sort((a, b) => a.sortOrder - b.sortOrder)
+        const next = [...prev]
+        next[idx] = payload
+        return next.sort((a, b) => a.sortOrder - b.sortOrder)
+      })
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Could not save item.")
+    }
+  }
+
+  const toggleChecked = async (
+    scope: PackingScope,
+    item: PackingItem,
+    checked: boolean,
+    setList: React.Dispatch<React.SetStateAction<PackingItem[]>>
+  ) => {
+    if (!trip?.id) return
+    setList((prev) =>
+      prev.map((row) => (row.id === item.id ? { ...row, isChecked: checked } : row))
+    )
+    try {
+      await updatePackingItemCheckedInSupabase(trip.id, item.id, checked)
+    } catch (e) {
+      setList((prev) =>
+        prev.map((row) => (row.id === item.id ? { ...row, isChecked: item.isChecked } : row))
+      )
+      toast.error(e instanceof Error ? e.message : "Could not update checkbox.")
+    }
+  }
+
+  const removeItem = async (
+    scope: PackingScope,
+    id: string,
+    setList: React.Dispatch<React.SetStateAction<PackingItem[]>>
+  ) => {
+    if (!trip?.id) return
+    const prevSnapshot = scope === "personal" ? personal : group
+    setList((prev) => prev.filter((x) => x.id !== id))
+    try {
+      await deletePackingItemFromSupabase(trip.id, id)
+    } catch (e) {
+      if (scope === "personal") setPersonal(prevSnapshot)
+      else setGroup(prevSnapshot)
+      toast.error(e instanceof Error ? e.message : "Could not remove item.")
+    }
+  }
+
+  const appendRow = (
+    scope: PackingScope,
+    list: PackingItem[],
+    options?: { syncDom?: boolean }
+  ): PackingItem | null => {
+    if (!trip?.id) return null
+    const setList = scope === "personal" ? setPersonal : setGroup
+    const item: PackingItem = {
+      id: newPackingId(trip.id, scope),
+      tripId: trip.id,
+      userId: scope === "group" ? null : "",
+      label: "",
+      isChecked: false,
+      sortOrder: nextSortOrder(list),
+    }
+    const append = (prev: PackingItem[]) => [...prev, item]
+    if (options?.syncDom) {
+      flushSync(() => setList(append))
+    } else {
+      setList(append)
+    }
+    void (async () => {
+      try {
+        await savePackingItemToSupabase(
+          trip.id,
+          {
+            id: item.id,
+            label: item.label,
+            isChecked: item.isChecked,
+            sortOrder: item.sortOrder,
+          },
+          scope
+        )
+      } catch (e) {
+        setList((prev) => prev.filter((x) => x.id !== item.id))
+        toast.error(e instanceof Error ? e.message : "Could not add item.")
+      }
+    })()
+    return item
+  }
+
+  const addItem = (scope: PackingScope) => {
+    const list = scope === "personal" ? personal : group
+    void appendRow(scope, list)
+  }
+
+  if (!trip) {
+    return <p className="text-sm text-muted-foreground">Loading trip…</p>
+  }
+
+  const renderSection = (
+    title: string,
+    description: string,
+    scope: PackingScope,
+    items: PackingItem[],
+    setList: React.Dispatch<React.SetStateAction<PackingItem[]>>
+  ) => (
+    <Card>
+      <CardHeader className="flex flex-col gap-3 space-y-0 sm:flex-row sm:flex-wrap sm:items-start sm:justify-between sm:gap-4">
+        <div className="min-w-0 flex-1">
+          <CardTitle className="text-lg">{title}</CardTitle>
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-11 w-full shrink-0 touch-manipulation sm:h-9 sm:w-auto"
+          onClick={() => addItem(scope)}
+        >
+          <PlusIcon className="size-4" />
+          Add item
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        ) : items.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No items yet. Add something to pack.</p>
+        ) : (
+          <ul className="space-y-3 sm:space-y-2">
+            {items.map((item) => (
+              <li
+                key={item.id}
+                className="flex flex-col gap-3 rounded-xl border border-border/90 bg-secondary/15 px-3 py-3 shadow-sm transition-colors hover:bg-secondary/25 dark:border-border dark:bg-secondary/25 dark:shadow-none dark:hover:bg-secondary/35 sm:flex-row sm:items-center sm:gap-3 sm:rounded-lg sm:px-3 sm:py-2.5"
+              >
+                <div className="flex min-w-0 flex-1 items-center gap-3">
+                  <Checkbox
+                    checked={item.isChecked}
+                    onCheckedChange={(v) =>
+                      void toggleChecked(scope, item, v === true, setList)
+                    }
+                    aria-label={`Packed: ${item.label || "item"}`}
+                    className="size-5 sm:size-4"
+                  />
+                  <Input
+                    ref={(el) => {
+                      if (el) inputRefs.current.set(item.id, el)
+                      else inputRefs.current.delete(item.id)
+                    }}
+                    className="min-h-11 flex-1 border-0 bg-transparent px-0 text-base text-foreground shadow-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background dark:bg-transparent dark:focus-visible:ring-ring/60 dark:focus-visible:ring-offset-background sm:min-h-9 sm:text-xs"
+                    value={item.label}
+                    placeholder="Item name"
+                    onChange={(e) =>
+                      setList((prev) =>
+                        prev.map((row) =>
+                          row.id === item.id ? { ...row, label: e.target.value } : row
+                        )
+                      )
+                    }
+                    onBlur={(e) => {
+                      const trimmed = e.target.value.trim()
+                      void persistItem(scope, { ...item, label: trimmed }, setList)
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key !== "Enter") return
+                      e.preventDefault()
+                      const input = e.currentTarget
+                      const trimmed = input.value.trim()
+                      void persistItem(scope, { ...item, label: trimmed }, setList)
+                      const idx = items.findIndex((r) => r.id === item.id)
+                      if (idx < 0) return
+                      if (idx < items.length - 1) {
+                        const nextId = items[idx + 1].id
+                        requestAnimationFrame(() => inputRefs.current.get(nextId)?.focus())
+                        return
+                      }
+                      const created = appendRow(scope, items, { syncDom: true })
+                      if (created) {
+                        requestAnimationFrame(() => inputRefs.current.get(created.id)?.focus())
+                      }
+                    }}
+                  />
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-10 shrink-0 touch-manipulation self-end text-destructive hover:bg-destructive/10 hover:text-destructive sm:size-8 sm:self-center dark:hover:bg-destructive/20"
+                  aria-label="Remove item"
+                  onClick={() => void removeItem(scope, item.id, setList)}
+                >
+                  <Trash2Icon className="size-5 sm:size-4" />
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+
+  const personalTitle = trip.isGroupTrip ? "Your packing" : "Packing list"
+  const personalDesc = trip.isGroupTrip
+    ? "Only you can see this list—your personal items on top of the shared group list."
+    : "Your checklist for this trip."
+
+  return (
+    <div className="space-y-6">
+      {renderSection(personalTitle, personalDesc, "personal", personal, setPersonal)}
+      {trip.isGroupTrip
+        ? renderSection(
+            "Group packing",
+            "Shared with everyone on this trip. Anyone in the group can add, check off, or remove items.",
+            "group",
+            group,
+            setGroup
+          )
+        : null}
+    </div>
+  )
+}

--- a/frontend/components/trips/trip-shell.tsx
+++ b/frontend/components/trips/trip-shell.tsx
@@ -75,6 +75,10 @@ const pageCopy: Record<string, { title: string; subtitle: string }> = {
     title: "Documents",
     subtitle: "Keep tickets and confirmations together for quick access.",
   },
+  packing: {
+    title: "Packing",
+    subtitle: "Personal checklist and shared group items so nothing gets left behind.",
+  },
 }
 
 function getPageKey(pathname: string): string {
@@ -114,7 +118,11 @@ export function TripShell({
   }, [user?.id])
 
   const pageKey = getPageKey(pathname)
-  const header = pageCopy[pageKey] || pageCopy.overview
+  const baseHeader = pageCopy[pageKey] || pageCopy.overview
+  const header =
+    pageKey === "packing" && !trip.isGroupTrip
+      ? { ...baseHeader, subtitle: "Your personal checklist for this trip." }
+      : baseHeader
   const pageDetails = [
     `destination=${trip.destination}`,
     `dates=${trip.startDate} to ${trip.endDate}`,

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -2,9 +2,11 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+/** React 19: `ref` is a normal prop on function components (no forwardRef needed). */
+function Input({ className, type, ref, ...props }: React.ComponentPropsWithRef<"input">) {
   return (
     <input
+      ref={ref}
       type={type}
       data-slot="input"
       className={cn(

--- a/frontend/lib/supabase-trip-packing.ts
+++ b/frontend/lib/supabase-trip-packing.ts
@@ -1,0 +1,122 @@
+import { createClient } from "@/lib/supabase/client"
+
+export type PackingScope = "group" | "personal"
+
+export type PackingItem = {
+  id: string
+  tripId: string
+  userId: string | null
+  label: string
+  isChecked: boolean
+  sortOrder: number
+}
+
+type TripPackingRow = {
+  id: string
+  trip_id: string
+  user_id: string | null
+  label: string
+  is_checked: boolean
+  sort_order: number
+}
+
+function rowToItem(row: TripPackingRow): PackingItem {
+  return {
+    id: row.id,
+    tripId: row.trip_id,
+    userId: row.user_id,
+    label: row.label ?? "",
+    isChecked: Boolean(row.is_checked),
+    sortOrder: Number(row.sort_order) || 0,
+  }
+}
+
+export async function listGroupPackingItemsFromSupabase(tripId: string): Promise<PackingItem[]> {
+  const supabase = createClient()
+  const { data: rows, error } = await supabase
+    .from("trip_packing_items")
+    .select("*")
+    .eq("trip_id", tripId)
+    .is("user_id", null)
+    .order("sort_order", { ascending: true })
+    .order("created_at", { ascending: true })
+  if (error) throw new Error(error.message)
+  return ((rows ?? []) as TripPackingRow[]).map(rowToItem)
+}
+
+export async function listPersonalPackingItemsFromSupabase(tripId: string): Promise<PackingItem[]> {
+  const supabase = createClient()
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+  if (userError || !user) return []
+
+  const { data: rows, error } = await supabase
+    .from("trip_packing_items")
+    .select("*")
+    .eq("trip_id", tripId)
+    .eq("user_id", user.id)
+    .order("sort_order", { ascending: true })
+    .order("created_at", { ascending: true })
+  if (error) throw new Error(error.message)
+  return ((rows ?? []) as TripPackingRow[]).map(rowToItem)
+}
+
+export type SavePackingItemPayload = {
+  id: string
+  label: string
+  isChecked: boolean
+  sortOrder: number
+}
+
+export async function savePackingItemToSupabase(
+  tripId: string,
+  payload: SavePackingItemPayload,
+  scope: PackingScope
+): Promise<void> {
+  const supabase = createClient()
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+  if (userError) throw new Error(userError.message)
+  if (!user) throw new Error("You must be signed in to save packing items.")
+
+  const userId = scope === "group" ? null : user.id
+  if (scope === "personal" && !userId) throw new Error("Missing user for personal packing.")
+
+  const { error } = await supabase.from("trip_packing_items").upsert(
+    {
+      id: payload.id,
+      trip_id: tripId,
+      user_id: userId,
+      label: payload.label.trim(),
+      is_checked: payload.isChecked,
+      sort_order: payload.sortOrder,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "id" }
+  )
+  if (error) throw new Error(error.message)
+}
+
+export async function updatePackingItemCheckedInSupabase(
+  tripId: string,
+  id: string,
+  isChecked: boolean
+): Promise<void> {
+  const supabase = createClient()
+  const { error } = await supabase
+    .from("trip_packing_items")
+    .update({ is_checked: isChecked, updated_at: new Date().toISOString() })
+    .eq("trip_id", tripId)
+    .eq("id", id)
+  if (error) throw new Error(error.message)
+}
+
+export async function deletePackingItemFromSupabase(tripId: string, id: string): Promise<void> {
+  const supabase = createClient()
+  const { error } = await supabase.from("trip_packing_items").delete().eq("trip_id", tripId).eq("id", id)
+  if (error) throw new Error(error.message)
+}

--- a/roadmap.md
+++ b/roadmap.md
@@ -36,6 +36,7 @@ Build an all-in-one travel platform for first-time travelers that plans, books, 
 - **AI assistant:** “plan it for me”, add bookings, explain options
 - **Finance layer:** multi-currency totals, group split ledger, budget timeline, FX alerts
 - **Group travel:** shared itineraries, approvals, split payments, group limits handling
+- **Packing lists:** personal checklist per trip; shared group list on group trips; synced checkboxes and labels
 
 ## Feature Breakdown (What Each Should Include)
 ### Flight Search & Booking (SerpAPI Google Flights)
@@ -91,6 +92,11 @@ Build an all-in-one travel platform for first-time travelers that plans, books, 
 - Split bookings (when >9 passengers)
 - Role permissions (owner/editor/viewer)
 
+### Packing Lists
+- Personal list (always) + group list (group trips only)
+- Add, rename, check off, remove items with realtime-friendly persistence
+- Clear separation of “yours” vs “shared with the group”
+
 ## UX Principles (First-Time Travelers)
 - Simple step-by-step flow (search → select → confirm)
 - Clear “best pick” explanations (price, time, baggage, stops)
@@ -102,6 +108,7 @@ Build an all-in-one travel platform for first-time travelers that plans, books, 
 - Auth, profiles, group model
 - Trip data schema
 - Base UI shell + navigation
+- Packing lists (personal + group) with database sync and row-level security
 
 ### Milestone 2 — Flights (SerpAPI)
 - Offer request + multi-city slices


### PR DESCRIPTION
## Summary
Adds per-trip packing checklists: a personal list for every trip and a shared group list when `isGroupTrip` is true. Items support add, edit, check off, and delete with Supabase persistence and RLS.

## Changes
- **Database:** `010_trip_packing.sql` — table, indexes, and policies for personal vs group scope.
- **Frontend:** `supabase-trip-packing.ts` CRUD, `/trips/[tripId]/packing` route, `PackingPageContent` with responsive/dark-friendly UI, Enter moves to next row (Input ref fix for React 19).
- **Nav:** Packing entry in trip nav and trip shell page copy.
- **Docs:** `roadmap.md` and landing roadmap section updated.

## Testing
- [x] Run migration against Supabase (or local Postgres) before QA.
- [x] Verify personal list on solo trip and personal + group sections on group trip.
- [x] Smoke-test add, rename, checkbox, delete, and Enter navigation on mobile width.

Made with [Cursor](https://cursor.com)